### PR TITLE
This is a commit to get this compiled with Debian Bullseye in 2022.

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,3 +15,19 @@ gem
 
 == Description
 rwx is a ruby extension that was created after wxRuby died.
+
+=== Install instructions
+
+For Debian Bullseye, you need to install packages ruby, ruby-dev, rubygems, wx-common, libwxgtk3.0-gtk3-dev, libwxbase3.0-dev, libgtk-3-dev, libwxgtk-media3.0-gtk3-dev and dependencies.
+
+You also need gcc and g++.
+
+If compilers error occur, you probably need to install other libraries!
+
+Test the compilation:
+
+- go to the rwx directory and type "rake", see whether it goes well
+- if all goes well then type sudo gem build rwx.gemspec
+
+This will install rwx to your computer's gem repository.
+

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -40,14 +40,16 @@ if(wxversion = pkg_config('wx', 'version'))
 	end
 	
 	wxcc = pkg_config('wx', 'cc')
-	unless wxcc == ruby_cc
-		abort("CC compiler missmatch %s == %s" % [wxcc, ruby_cc])
-	end
+# there's no actual need to check "compiler compatibility" because Linux compilers make
+# compatible ABI calls anyway.
+#	unless wxcc == ruby_cc
+#		abort("CC compiler missmatch %s == %s" % [wxcc, ruby_cc])
+#	end
 	
 	wxcxx = pkg_config('wx', 'cxx')
-	unless wxcxx == ruby_cxx
-		abort("CXX compiler missmatch %s == %s" % [wxcxx, ruby_cxx])
-	end
+#	unless wxcxx == ruby_cxx
+#		abort("CXX compiler missmatch %s == %s" % [wxcxx, ruby_cxx])
+#	end
 	
 	#earlier versions of ruby does not have that constant
 	$CXXFLAGS = CONFIG["CXXFLAGS"] unless defined?($CXXFLAGS)
@@ -67,7 +69,7 @@ if(wxversion = pkg_config('wx', 'version'))
 		$CXXFLAGS << " " << pkg[0] if pkg && !$CXXFLAGS[pkg[0]]
 	}
 	
-	all = " -fvisibility-inlines-hidden"
+	all = " -fvisibility-inlines-hidden -fpermissive"
 	$CFLAGS << all << " -x c++ -g "
 	$CXXFLAGS << all << " -g "
 	$CPPFLAGS << all << " -g "

--- a/ext/extconf.rb
+++ b/ext/extconf.rb
@@ -69,7 +69,8 @@ if(wxversion = pkg_config('wx', 'version'))
 		$CXXFLAGS << " " << pkg[0] if pkg && !$CXXFLAGS[pkg[0]]
 	}
 	
-	all = " -fvisibility-inlines-hidden -fpermissive"
+	all = " -fvisibility-inlines-hidden"
+
 	$CFLAGS << all << " -x c++ -g "
 	$CXXFLAGS << all << " -g "
 	$CPPFLAGS << all << " -g "

--- a/ext/rwx.cpp
+++ b/ext/rwx.cpp
@@ -225,10 +225,16 @@ VALUE rb_mWX;
 
 void rb_define_attr_method_base(VALUE klass,const std::string& name,VALUE(get)(ANYARGS),VALUE(set)(ANYARGS), bool missing = false)
 {
-	if(get)
-		rb_define_method(klass,name.c_str(),RUBY_METHOD_FUNC(get), missing ? -1 : 0);
-	if(set)
-		rb_define_method(klass,(name + "=").c_str(),RUBY_METHOD_FUNC(set), missing ? -1 : 1);
+    /* let's get this to compile: macro expects a constant */
+	if(get && missing)
+		rb_define_method(klass,name.c_str(),RUBY_METHOD_FUNC(get), -1);
+    else if (get && ! missing)
+		rb_define_method(klass,name.c_str(),RUBY_METHOD_FUNC(get), 0);    
+	if(set && missing)
+		rb_define_method(klass,(name + "=").c_str(),RUBY_METHOD_FUNC(set), -1);
+    else if (set && ! missing)
+		rb_define_method(klass,(name + "=").c_str(),RUBY_METHOD_FUNC(set), 1);
+
 }
 
 void rb_define_attr_method(VALUE klass,const std::string& name,VALUE(get)(VALUE),VALUE(set)(VALUE,VALUE))


### PR DESCRIPTION
Hi Hanmac,

I have made some changes to get your library to compile in 2022 on a Stable Debian distribution.

Modified:

- README.rdoc to add basic compilation instructions and library dependency info
- ext/rwx.cpp to refactor some code that fails to compile due to compiler update (something about constants)
- ext/extconf.rb with 2 changes:
  * addition of a -fpermissive flag so as to turn some other C++ errors into warnings
  * removing gcc / wx gcc similarity check because you do not actually need to use exactly the same compiler to get code working with shared libraries.

Would you consider looking into this and giving me your thoughts?

Many tia,

Mathieu